### PR TITLE
Ddded option to use CLI in server environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ek
+.DS_Store

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -29,6 +29,10 @@ This command will open a web browser to complete the OAuth authentication flow.
 After successful authentication, your credentials will be securely stored
 in your system's keyring.
 
+For server environments where browser authentication is not possible, you can
+set the ENKRYPTIFY_TOKEN environment variable with your API token:
+  export ENKRYPTIFY_TOKEN=your_api_token_here
+
 Examples:
   ek login              # Login with default provider (Enkryptify)
   ek login --force      # Force re-authentication even if already logged in

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.8"
+var version = "0.1.9"
 
 var rootCmd = &cobra.Command{
 	Use:   "ek",

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.1.8"
+VERSION="0.1.9"
 set -e
 
 if [ -t 1 ]; then

--- a/internal/providers/enkryptify/provider.go
+++ b/internal/providers/enkryptify/provider.go
@@ -69,6 +69,19 @@ type SecretValue struct {
 	Value         string `json:"value"`
 }
 
+type ProjectTokenResponse struct {
+	ID        string `json:"id"`
+	Workspace struct {
+		ID   string `json:"id"`
+		Slug string `json:"slug"`
+	} `json:"workspace"`
+	Project struct {
+		ID   string `json:"id"`
+		Slug string `json:"slug"`
+	} `json:"project"`
+	EnvironmentID string `json:"environmentId"`
+}
+
 func NewClient() *Client {
 	return &Client{
 		httpClient: &http.Client{Timeout: 30 * time.Second},
@@ -154,4 +167,14 @@ func (c *Client) GetSecrets(workspaceSlug, projectSlug, environmentID string) ([
 	}
 
 	return secrets, nil
+}
+
+func (c *Client) GetProjectTokenDetails() (*ProjectTokenResponse, error) {
+	var tokenDetails ProjectTokenResponse
+
+	if err := c.makeRequest("GET", "/auth/project-token", &tokenDetails); err != nil {
+		return nil, fmt.Errorf("failed to get project token details: %w", err)
+	}
+
+	return &tokenDetails, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added headless authentication via ENKRYPTIFY_TOKEN, allowing login without a browser.
  - Introduced non-interactive setup when ENKRYPTIFY_TOKEN is present, auto-detecting workspace, project, and environment and saving the configuration.

- Documentation
  - Updated login help text to explain using ENKRYPTIFY_TOKEN, including an example export command.

- Chores
  - Bumped CLI version to 0.1.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->