### PR TITLE
bump version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.9"
+var version = "0.1.10"
 
 var rootCmd = &cobra.Command{
 	Use:   "ek",

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.1.9"
+VERSION="0.1.10"
 set -e
 
 if [ -t 1 ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated application version to 0.1.10 across the CLI and installation script.
  - The CLI now reports version 0.1.10 when queried.
  - The installer will install version 0.1.10 by default.
  - No functional behavior changes; this is a version alignment for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->