### PR TITLE
feat: add logout & whoami commands

### DIFF
--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -3,15 +3,19 @@ import { registerCreateCommand } from "@/cmd/create";
 import { registerDeleteCommand } from "@/cmd/delete";
 import { registerListCommand } from "@/cmd/listCommand";
 import { registerLoginCommand } from "@/cmd/login";
+import { registerLogoutCommand } from "@/cmd/logout";
 import { registerRunCommand } from "@/cmd/run";
 import { registerRunFileCommand } from "@/cmd/run-file";
 import { registerSdkCommand } from "@/cmd/sdk";
 import { registerUpdateCommand } from "@/cmd/update";
 import { registerUpgradeCommand } from "@/cmd/upgrade";
+import { registerWhoamiCommand } from "@/cmd/whoami";
 import type { Command } from "commander";
 
 export function registerCommands(program: Command) {
     registerLoginCommand(program);
+    registerLogoutCommand(program);
+    registerWhoamiCommand(program);
     registerConfigureCommand(program);
     registerRunCommand(program);
     registerRunFileCommand(program);

--- a/src/cmd/logout.ts
+++ b/src/cmd/logout.ts
@@ -1,0 +1,51 @@
+import http from "@/api/httpClient";
+import { analytics } from "@/lib/analytics";
+import { config as configManager } from "@/lib/config";
+import { keyring } from "@/lib/keyring";
+import { logger } from "@/lib/logger";
+import type { Command } from "commander";
+
+export function registerLogoutCommand(program: Command) {
+    program
+        .command("logout")
+        .description("Log out of Enkryptify and revoke your CLI token.")
+        .option("--all", "Revoke all CLI tokens for your account")
+        .action(async (options: { all?: boolean }) => {
+            const tracker = analytics.trackCommand("command_logout", {
+                all: !!options.all,
+            });
+
+            try {
+                const authDataString = await keyring.get("enkryptify");
+                if (!authDataString) {
+                    logger.info("You are not logged in.");
+                    tracker.success();
+                    return;
+                }
+
+                // Attempt to revoke the token server-side
+                try {
+                    await http.post("/v1/auth/cli/logout", {
+                        ...(options.all ? { all: true } : {}),
+                    });
+                } catch (revokeError: unknown) {
+                    logger.warn("Could not revoke your token on the server.", {
+                        why: "The server may be unreachable or the token may already be invalid.",
+                        fix: "Your local credentials have been cleared. If needed, revoke tokens from the Enkryptify dashboard.",
+                    });
+                    logger.debug(revokeError instanceof Error ? revokeError.message : String(revokeError));
+                }
+
+                // Always clear local credentials regardless of API result
+                await keyring.delete("enkryptify");
+                await configManager.clearAuthentication();
+
+                logger.info("Successfully logged out.");
+                tracker.success();
+            } catch (error: unknown) {
+                tracker.error(error instanceof Error ? error : new Error(String(error)));
+                logger.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/cmd/whoami.ts
+++ b/src/cmd/whoami.ts
@@ -1,0 +1,57 @@
+import { Auth } from "@/api/auth";
+import { analytics } from "@/lib/analytics";
+import { keyring } from "@/lib/keyring";
+import { logger } from "@/lib/logger";
+import type { Command } from "commander";
+
+export function registerWhoamiCommand(program: Command) {
+    program
+        .command("whoami")
+        .description("Show the currently authenticated user.")
+        .action(async () => {
+            const tracker = analytics.trackCommand("command_whoami", {});
+
+            try {
+                const authDataString = await keyring.get("enkryptify");
+                if (!authDataString) {
+                    logger.warn("Not logged in.", {
+                        fix: 'Run "ek login" to authenticate.',
+                    });
+                    tracker.success();
+                    return;
+                }
+
+                const authData = JSON.parse(authDataString) as {
+                    accessToken: string;
+                    userId: string;
+                    email: string;
+                };
+
+                if (!authData.accessToken) {
+                    logger.warn("Not logged in.", {
+                        fix: 'Run "ek login" to authenticate.',
+                    });
+                    tracker.success();
+                    return;
+                }
+
+                const auth = new Auth();
+                const userInfo = await auth.getUserInfo(authData.accessToken);
+
+                if (!userInfo) {
+                    logger.warn("Your session has expired or is invalid.", {
+                        fix: 'Run "ek login" to re-authenticate.',
+                    });
+                    tracker.success();
+                    return;
+                }
+
+                logger.info(`Logged in as ${userInfo.name} (${userInfo.email})`);
+                tracker.success();
+            } catch (error: unknown) {
+                tracker.error(error instanceof Error ? error : new Error(String(error)));
+                logger.error(error instanceof Error ? error.message : String(error));
+                process.exit(1);
+            }
+        });
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -179,6 +179,12 @@ async function markAuthenticated(): Promise<void> {
     await saveConfig(config);
 }
 
+async function clearAuthentication(): Promise<void> {
+    const config = await loadConfig();
+    delete config.providers["enkryptify"];
+    await saveConfig(config);
+}
+
 async function isAuthenticated(): Promise<boolean> {
     const config = await loadConfig();
     return config.providers?.["enkryptify"] != null;
@@ -227,6 +233,7 @@ async function findProjectConfig(startPath: string): Promise<ProjectConfig> {
 
 export const config = {
     markAuthenticated,
+    clearAuthentication,
     isAuthenticated,
     createConfigure,
     getConfigure,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -77,6 +77,13 @@ export const CLI_ERRORS = {
         fix: "Close the application using that port and try again.",
     },
 
+    // Logout
+    LOGOUT_REVOKE_FAILED: {
+        message: "Could not revoke your token on the server.",
+        why: "The server may be unreachable or the token may already be invalid.",
+        fix: "Your local credentials have been cleared. If needed, revoke tokens from the Enkryptify dashboard.",
+    },
+
     // Configuration
     CONFIG_NOT_FOUND: {
         message: "No project configured for this directory.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logout command (with --all) to revoke tokens, clear local credentials, and confirm logout.
  * Added whoami command to display the current authenticated user's name and email or prompt to login.

* **Improvements**
  * Improved session cleanup with an explicit local auth-clear action.
  * Clearer error/warning messages when server-side token revocation or session checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->