### PR TITLE
fix: harden CLI against RCE

### DIFF
--- a/src/cmd/run-file.ts
+++ b/src/cmd/run-file.ts
@@ -3,6 +3,7 @@ import { analytics } from "@/lib/analytics";
 import { CLIError } from "@/lib/errors";
 import { isDangerousEnvVar } from "@/lib/inject";
 import { logger } from "@/lib/logger";
+import { writeStdout } from "@/lib/stdout";
 import { type Secret, client } from "@/api/client";
 import { fetchSecretsWithCache } from "@/lib/secretCache";
 import { RunFlow } from "@/ui/RunFlow";
@@ -80,7 +81,7 @@ export async function runFileCommand(
     const processedContent = replaceVariables(content, secrets, {
         allowDangerousVars: options?.allowDangerousVars,
     });
-    process.stdout.write(processedContent);
+    await writeStdout(processedContent);
 }
 
 export function registerRunFileCommand(program: Command) {
@@ -133,6 +134,7 @@ export function registerRunFileCommand(program: Command) {
                     tracker.success({
                         workspace_slug: projectConfig.workspace_slug,
                     });
+                    process.exit(0);
                 } catch (error) {
                     tracker.error(error);
                     if (error instanceof CLIError) {

--- a/src/cmd/run-file.ts
+++ b/src/cmd/run-file.ts
@@ -1,13 +1,18 @@
 import { type ProjectConfig, config } from "@/lib/config";
 import { analytics } from "@/lib/analytics";
 import { CLIError } from "@/lib/errors";
+import { isDangerousEnvVar } from "@/lib/inject";
 import { logger } from "@/lib/logger";
 import { type Secret, client } from "@/api/client";
 import { fetchSecretsWithCache } from "@/lib/secretCache";
 import { RunFlow } from "@/ui/RunFlow";
 import type { Command } from "commander";
 
-export function replaceVariables(content: string, secrets: Secret[]): string {
+export function replaceVariables(
+    content: string,
+    secrets: Secret[],
+    options?: { allowDangerousVars?: boolean },
+): string {
     const secretMap = new Map<string, string>();
     for (const secret of secrets) {
         if (secret.name && secret.value != null) {
@@ -18,7 +23,12 @@ export function replaceVariables(content: string, secrets: Secret[]): string {
     return content.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, varName: string) => {
         const value = secretMap.get(varName);
         if (value !== undefined) {
-            return value;
+            if (!options?.allowDangerousVars && isDangerousEnvVar(varName)) {
+                logger.stderr.warn(
+                    `Secret "${varName}" matches a protected environment variable name. Use --allow-dangerous-vars to suppress this warning.`,
+                );
+            }
+            return value.replace(/\r/g, "");
         }
 
         logger.stderr.warn(`Variable "${varName}" was not found in your secrets and will be left unchanged.`);
@@ -29,7 +39,13 @@ export function replaceVariables(content: string, secrets: Secret[]): string {
 export async function runFileCommand(
     projectConfig: ProjectConfig,
     filePath: string,
-    options?: { env?: string; noCache?: boolean; offline?: boolean; unmountSpinner?: () => void },
+    options?: {
+        env?: string;
+        noCache?: boolean;
+        offline?: boolean;
+        allowDangerousVars?: boolean;
+        unmountSpinner?: () => void;
+    },
 ): Promise<void> {
     const { secrets, fromCache, cacheReason } = await fetchSecretsWithCache(
         projectConfig,
@@ -61,7 +77,9 @@ export async function runFileCommand(
     }
 
     const content = await file.text();
-    const processedContent = replaceVariables(content, secrets);
+    const processedContent = replaceVariables(content, secrets, {
+        allowDangerousVars: options?.allowDangerousVars,
+    });
     process.stdout.write(processedContent);
 }
 
@@ -74,43 +92,56 @@ export function registerRunFileCommand(program: Command) {
         .option("-e, --env <environmentName>", "Environment name to use (overrides default from config)")
         .option("--skip-cache", "Skip cache and always fetch fresh secrets from the API")
         .option("--offline", "Use cached secrets without contacting the API")
-        .action(async (opts: { file: string; env?: string; skipCache?: boolean; offline?: boolean }) => {
-            const tracker = analytics.trackCommand("command_run_file", {
-                has_env_flag: !!opts.env,
-                skip_cache: !!opts.skipCache,
-                offline: !!opts.offline,
-            });
-
-            try {
-                if (opts.skipCache && opts.offline) {
-                    throw CLIError.from("COMMAND_CONFLICTING_FLAGS");
-                }
-
-                const projectConfig: ProjectConfig = await config.findProjectConfig(process.cwd());
-
-                await RunFlow({
-                    envName: opts.env,
-                    run: async (unmountSpinner) => {
-                        await runFileCommand(projectConfig, opts.file, {
-                            env: opts.env,
-                            noCache: opts.skipCache,
-                            offline: opts.offline,
-                            unmountSpinner,
-                        });
-                    },
+        .option(
+            "--allow-dangerous-vars",
+            "Suppress warnings when substituting protected environment variable names (PATH, NODE_OPTIONS, etc.)",
+        )
+        .action(
+            async (opts: {
+                file: string;
+                env?: string;
+                skipCache?: boolean;
+                offline?: boolean;
+                allowDangerousVars?: boolean;
+            }) => {
+                const tracker = analytics.trackCommand("command_run_file", {
+                    has_env_flag: !!opts.env,
+                    skip_cache: !!opts.skipCache,
+                    offline: !!opts.offline,
                 });
 
-                tracker.success({
-                    workspace_slug: projectConfig.workspace_slug,
-                });
-            } catch (error) {
-                tracker.error(error);
-                if (error instanceof CLIError) {
-                    logger.error(error.message, { why: error.why, fix: error.fix, docs: error.docs });
-                } else {
-                    logger.error(error instanceof Error ? error.message : String(error));
+                try {
+                    if (opts.skipCache && opts.offline) {
+                        throw CLIError.from("COMMAND_CONFLICTING_FLAGS");
+                    }
+
+                    const projectConfig: ProjectConfig = await config.findProjectConfig(process.cwd());
+
+                    await RunFlow({
+                        envName: opts.env,
+                        run: async (unmountSpinner) => {
+                            await runFileCommand(projectConfig, opts.file, {
+                                env: opts.env,
+                                noCache: opts.skipCache,
+                                offline: opts.offline,
+                                allowDangerousVars: opts.allowDangerousVars,
+                                unmountSpinner,
+                            });
+                        },
+                    });
+
+                    tracker.success({
+                        workspace_slug: projectConfig.workspace_slug,
+                    });
+                } catch (error) {
+                    tracker.error(error);
+                    if (error instanceof CLIError) {
+                        logger.error(error.message, { why: error.why, fix: error.fix, docs: error.docs });
+                    } else {
+                        logger.error(error instanceof Error ? error.message : String(error));
+                    }
+                    process.exit(1);
                 }
-                process.exit(1);
-            }
-        });
+            },
+        );
 }

--- a/src/cmd/run.ts
+++ b/src/cmd/run.ts
@@ -157,6 +157,7 @@ export function registerRunCommand(program: Command) {
                         cache_reason: result?.cacheReason,
                         exit_code: result?.exitCode ?? 0,
                     });
+                    process.exit(result?.exitCode ?? 0);
                 } catch (error) {
                     tracker.error(error);
                     if (error instanceof CLIError) {

--- a/src/cmd/run.ts
+++ b/src/cmd/run.ts
@@ -11,7 +11,15 @@ import type { Command } from "commander";
 export async function runCommand(
     projectconfig: ProjectConfig,
     cmd: string[],
-    options?: { env?: string; project?: string; noCache?: boolean; offline?: boolean; unmountSpinner?: () => void },
+    options?: {
+        env?: string;
+        project?: string;
+        noCache?: boolean;
+        offline?: boolean;
+        prefix?: string;
+        allowDangerousVars?: boolean;
+        unmountSpinner?: () => void;
+    },
 ): Promise<{ fromCache: boolean; cacheReason?: string; exitCode: number }> {
     const { secrets, fromCache, cacheReason } = await fetchSecretsWithCache(
         projectconfig,
@@ -19,7 +27,10 @@ export async function runCommand(
         { noCache: options?.noCache, offline: options?.offline },
         () => client.run(projectconfig, { env: options?.env, project: options?.project }),
     );
-    const env = buildEnvWithSecrets(secrets);
+    const { env, injectedCount, skippedSecrets } = buildEnvWithSecrets(secrets, {
+        prefix: options?.prefix,
+        allowDangerousVars: options?.allowDangerousVars,
+    });
 
     // Unmount spinner right after secrets are fetched, before command runs
     if (options?.unmountSpinner) {
@@ -34,7 +45,10 @@ export async function runCommand(
         logger.stderr.info("Using cached secrets. Use --skip-cache to force a fresh fetch.");
     }
 
-    let successMessage = "Secrets injected successfully";
+    let successMessage = `${injectedCount} secret${injectedCount !== 1 ? "s" : ""} injected`;
+    if (skippedSecrets.length > 0) {
+        successMessage += `, ${skippedSecrets.length} skipped (${skippedSecrets.join(", ")})`;
+    }
     if (options?.project) {
         successMessage += ` for project "${options.project}"`;
     }
@@ -80,12 +94,27 @@ export function registerRunCommand(program: Command) {
         .option("-p, --project <projectName>", "Project name to use (overrides default from config)")
         .option("--skip-cache", "Skip cache and always fetch fresh secrets from the API")
         .option("--offline", "Use cached secrets without contacting the API")
+        .option("--prefix <prefix>", "Prefix all injected secret names (e.g., --prefix EK_)")
+        .option(
+            "--allow-dangerous-vars",
+            "Allow secrets to override protected environment variables (PATH, NODE_OPTIONS, etc.)",
+        )
         .argument(
             "<cmd...>",
             "Command and arguments to run (e.g. 'pnpm run dev' or use '--' to separate: 'ek run -- pnpm run dev')",
         )
         .action(
-            async (cmd: string[], opts: { env?: string; project?: string; skipCache?: boolean; offline?: boolean }) => {
+            async (
+                cmd: string[],
+                opts: {
+                    env?: string;
+                    project?: string;
+                    skipCache?: boolean;
+                    offline?: boolean;
+                    prefix?: string;
+                    allowDangerousVars?: boolean;
+                },
+            ) => {
                 const tracker = analytics.trackCommand("command_run", {
                     has_env_flag: !!opts.env,
                     has_project_flag: !!opts.project,
@@ -115,6 +144,8 @@ export function registerRunCommand(program: Command) {
                                 project: opts.project,
                                 noCache: opts.skipCache,
                                 offline: opts.offline,
+                                prefix: opts.prefix,
+                                allowDangerousVars: opts.allowDangerousVars,
                                 unmountSpinner,
                             });
                         },

--- a/src/cmd/sdk.ts
+++ b/src/cmd/sdk.ts
@@ -3,6 +3,7 @@ import { analytics } from "@/lib/analytics";
 import { CLIError } from "@/lib/errors";
 import { logger } from "@/lib/logger";
 import { createSdkToken } from "@/lib/sdkToken";
+import { writeStdout } from "@/lib/stdout";
 import type { Command } from "commander";
 
 export function registerSdkCommand(program: Command): void {
@@ -57,13 +58,9 @@ export function registerSdkCommand(program: Command): void {
 
             // 3. Stdout mode: print token and exit
             if (options.output === "stdout") {
-                if (process.stdout.isTTY) {
-                    process.stdout.write(`${token}\n`);
-                } else {
-                    process.stdout.write(token);
-                }
+                await writeStdout(process.stdout.isTTY ? `${token}\n` : token);
                 tracker.success({ workspace_slug: setup.workspace_slug });
-                return;
+                process.exit(0);
             }
 
             // 4. Env mode (default): require command args, spawn subprocess

--- a/src/cmd/sdk.ts
+++ b/src/cmd/sdk.ts
@@ -2,23 +2,23 @@ import { config } from "@/lib/config";
 import { analytics } from "@/lib/analytics";
 import { CLIError } from "@/lib/errors";
 import { logger } from "@/lib/logger";
-import http from "@/api/httpClient";
+import { createSdkToken } from "@/lib/sdkToken";
 import type { Command } from "commander";
 
 export function registerSdkCommand(program: Command): void {
     program
         .command("sdk")
-        .description("Run a command with a read-only Enkryptify SDK token")
+        .description("Run a command with a read-only Enkryptify SDK token, or print the token to stdout.")
+        .option("-o, --output <mode>", 'Token delivery mode: "env" (default) injects as ENKRYPTIFY_TOKEN, "stdout" prints the raw token', "env")
         .allowUnknownOption()
         .allowExcessArguments()
-        .action(async (_options, cmd: Command) => {
+        .action(async (options: { output: string }, cmd: Command) => {
             const tracker = analytics.trackCommand("command_sdk");
 
-            const args = cmd.args as string[];
-            if (args.length === 0) {
-                tracker.error(new Error("No command provided"));
-                logger.error("No command provided.", {
-                    fix: "Usage: ek sdk -- <command>",
+            if (options.output !== "env" && options.output !== "stdout") {
+                tracker.error(new Error("Invalid output mode"));
+                logger.error(`Invalid output mode "${options.output}".`, {
+                    fix: 'Use --output env (default) or --output stdout.',
                 });
                 process.exit(1);
             }
@@ -31,23 +31,20 @@ export function registerSdkCommand(program: Command): void {
                 // getConfigure returns null if not found, doesn't throw
             }
 
-            if (!setup) {
+            if (!setup?.workspace_slug || !setup?.environment_id) {
                 tracker.error(new Error("No project configured"));
                 logger.error("No project configured in this directory.", {
                     fix: 'Run "ek configure" to set up your project first.',
                     docs: "/cli/troubleshooting#configuration",
                 });
                 process.exit(1);
+                return;
             }
 
             // 2. Create scoped SDK token (read-only, single environment, 8h)
             let token: string;
             try {
-                const { data } = await http.post<{ token: string }>(
-                    `/v1/workspace/${setup.workspace_slug}/tokens/cli`,
-                    { environmentId: setup.environment_id },
-                );
-                token = data.token;
+                token = await createSdkToken(setup.workspace_slug, setup.environment_id);
             } catch (error) {
                 tracker.error(error);
                 if (error instanceof CLIError) {
@@ -58,12 +55,32 @@ export function registerSdkCommand(program: Command): void {
                 process.exit(1);
             }
 
-            // 3. Spawn child process with token injected
+            // 3. Stdout mode: print token and exit
+            if (options.output === "stdout") {
+                if (process.stdout.isTTY) {
+                    process.stdout.write(`${token}\n`);
+                } else {
+                    process.stdout.write(token);
+                }
+                tracker.success({ workspace_slug: setup.workspace_slug });
+                return;
+            }
+
+            // 4. Env mode (default): require command args, spawn subprocess
+            const args = cmd.args as string[];
+            if (args.length === 0) {
+                tracker.error(new Error("No command provided"));
+                logger.error("No command provided.", {
+                    fix: "Usage: ek sdk -- <command>  or  ek sdk --output stdout",
+                });
+                process.exit(1);
+            }
+
             const [bin, ...rest] = args;
             if (!bin) {
                 tracker.error(new Error("No command provided"));
                 logger.error("No command provided.", {
-                    fix: "Usage: ek sdk -- <command>",
+                    fix: "Usage: ek sdk -- <command>  or  ek sdk --output stdout",
                 });
                 process.exit(1);
             }

--- a/src/lib/inject.ts
+++ b/src/lib/inject.ts
@@ -142,23 +142,25 @@ export function buildEnvWithSecrets(
     for (const secret of secrets) {
         if (!secret?.name || secret.value == null) continue;
 
-        if (!options?.allowDangerousVars && isDangerousEnvVar(secret.name)) {
+        const envName = options?.prefix ? `${options.prefix}${secret.name}` : secret.name;
+
+        if (!options?.allowDangerousVars && isDangerousEnvVar(envName)) {
             logger.warn(
-                `Secret "${secret.name}" was skipped. It conflicts with a protected environment variable (${secret.name.toUpperCase()}).`,
+                `Secret "${secret.name}" was skipped. It conflicts with a protected environment variable (${envName.toUpperCase()}).`,
             );
-            skippedSecrets.push(secret.name);
+            skippedSecrets.push(envName);
             continue;
         }
 
         if (secret.name.includes("\0")) {
             logger.warn(`Secret "${secret.name}" was skipped. The name contains invalid characters.`);
-            skippedSecrets.push(secret.name);
+            skippedSecrets.push(envName);
             continue;
         }
 
         if (typeof secret.value !== "string" || secret.value.includes("\0")) {
             logger.warn(`Secret "${secret.name}" was skipped. The value is invalid.`);
-            skippedSecrets.push(secret.name);
+            skippedSecrets.push(envName);
             continue;
         }
 
@@ -168,7 +170,6 @@ export function buildEnvWithSecrets(
             );
         }
 
-        const envName = options?.prefix ? `${options.prefix}${secret.name}` : secret.name;
         env[envName] = secret.value;
         injectedCount++;
     }

--- a/src/lib/inject.ts
+++ b/src/lib/inject.ts
@@ -2,31 +2,93 @@ import type { Secret } from "@/api/client";
 import { logger } from "@/lib/logger";
 
 /**
- * Environment variables that should never be overridden by secrets
- * These control critical system behavior and could be exploited
+ * Environment variables that should never be overridden by secrets.
+ * These control critical system/runtime behavior and could be exploited.
+ *
+ * This blocklist is best-effort and cannot be exhaustive.
+ * For stronger isolation, use --prefix to namespace all injected secrets.
  */
 const DANGEROUS_ENV_VARS = new Set([
+    // System paths
     "PATH",
     "PATHEXT",
 
+    // Library loading (Linux)
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "LD_PROFILE",
+
+    // Library loading (macOS)
     "DYLD_LIBRARY_PATH",
     "DYLD_INSERT_LIBRARIES",
     "DYLD_FRAMEWORK_PATH",
 
-    "PYTHONPATH",
+    // Java / JVM
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+
+    // Node.js
+    "NODE_OPTIONS",
     "NODE_PATH",
-    "PERL5LIB",
+    "NODE_EXTRA_CA_CERTS",
+
+    // Python
+    "PYTHONPATH",
+    "PYTHONSTARTUP",
+    "PYTHONHOME",
+
+    // Ruby
     "RUBYLIB",
+    "RUBYOPT",
+    "GEM_HOME",
+    "GEM_PATH",
+
+    // Perl
+    "PERL5LIB",
+    "PERL5OPT",
+    "PERLLIB",
+
+    // .NET
+    "DOTNET_STARTUP_HOOKS",
+    "COR_ENABLE_PROFILING",
+    "COR_PROFILER",
+    "COR_PROFILER_PATH",
+
+    // Go / Rust
+    "GOFLAGS",
+    "RUSTFLAGS",
+
+    // Java classpath
     "CLASSPATH",
 
+    // Shell execution
     "IFS",
     "CDPATH",
     "ENV",
     "BASH_ENV",
     "SHELL",
+    "PROMPT_COMMAND",
 
+    // Proxy (traffic interception)
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "FTP_PROXY",
+    "NO_PROXY",
+
+    // SSL/TLS (MitM)
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+
+    // Git
+    "GIT_SSH_COMMAND",
+    "GIT_CONFIG_GLOBAL",
+
+    // User context
     "HOME",
     "USER",
     "USERNAME",
@@ -50,37 +112,66 @@ const DANGEROUS_ENV_VARS = new Set([
     "PSMODULEPATH",
 ]);
 
-function isDangerousEnvVar(name: string): boolean {
+export function isDangerousEnvVar(name: string): boolean {
     if (!name || typeof name !== "string") {
         return false;
     }
     return DANGEROUS_ENV_VARS.has(name.toUpperCase());
 }
 
-export function buildEnvWithSecrets(secrets: Secret[]): typeof process.env {
+export type InjectResult = {
+    env: typeof process.env;
+    injectedCount: number;
+    skippedSecrets: string[];
+};
+
+export function buildEnvWithSecrets(
+    secrets: Secret[],
+    options?: { prefix?: string; allowDangerousVars?: boolean },
+): InjectResult {
     const env = { ...process.env };
+    let injectedCount = 0;
+    const skippedSecrets: string[] = [];
+
+    if (options?.allowDangerousVars) {
+        logger.warn(
+            "Protected environment variable checks are disabled (--allow-dangerous-vars). Secrets may override critical system variables.",
+        );
+    }
 
     for (const secret of secrets) {
         if (!secret?.name || secret.value == null) continue;
 
-        if (isDangerousEnvVar(secret.name)) {
+        if (!options?.allowDangerousVars && isDangerousEnvVar(secret.name)) {
             logger.warn(
                 `Secret "${secret.name}" was skipped. It conflicts with a protected environment variable (${secret.name.toUpperCase()}).`,
             );
+            skippedSecrets.push(secret.name);
             continue;
         }
 
         if (secret.name.includes("\0")) {
             logger.warn(`Secret "${secret.name}" was skipped. The name contains invalid characters.`);
+            skippedSecrets.push(secret.name);
             continue;
         }
 
         if (typeof secret.value !== "string" || secret.value.includes("\0")) {
             logger.warn(`Secret "${secret.name}" was skipped. The value is invalid.`);
+            skippedSecrets.push(secret.name);
             continue;
         }
-        env[secret.name] = secret.value;
+
+        if (secret.value.includes("\r")) {
+            logger.warn(
+                `Secret "${secret.name}" contains carriage return (\\r) characters. This may cause unexpected behavior.`,
+            );
+        }
+
+        const envName = options?.prefix ? `${options.prefix}${secret.name}` : secret.name;
+        env[envName] = secret.value;
+        injectedCount++;
     }
 
-    return env;
+    return { env, injectedCount, skippedSecrets };
 }

--- a/src/lib/sdkToken.ts
+++ b/src/lib/sdkToken.ts
@@ -1,0 +1,9 @@
+import http from "@/api/httpClient";
+
+export async function createSdkToken(workspaceSlug: string, environmentId: string): Promise<string> {
+    const { data } = await http.post<{ token: string }>(
+        `/v1/workspace/${workspaceSlug}/tokens/cli`,
+        { environmentId },
+    );
+    return data.token;
+}

--- a/src/lib/stdout.ts
+++ b/src/lib/stdout.ts
@@ -1,0 +1,12 @@
+export async function writeStdout(value: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        process.stdout.write(value, (error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+
+            resolve();
+        });
+    });
+}

--- a/tests/integration/command-fast-exit.test.ts
+++ b/tests/integration/command-fast-exit.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { FAKE_PROJECT_CONFIG, FAKE_SECRETS } from "../helpers/fixtures";
+
+vi.mock("@/lib/logger", () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        success: vi.fn(),
+        stderr: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            success: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/config", () => ({
+    config: {
+        findProjectConfig: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/analytics", () => ({
+    analytics: {
+        trackCommand: vi.fn(),
+    },
+}));
+
+vi.mock("@/api/client", () => ({
+    client: {
+        run: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/secretCache", () => ({
+    fetchSecretsWithCache: vi.fn(),
+}));
+
+vi.mock("@/ui/RunFlow", () => ({
+    RunFlow: vi.fn(async ({ run }) => {
+        await run(vi.fn());
+    }),
+}));
+
+import { analytics, type CommandTracker } from "@/lib/analytics";
+import { registerRunCommand } from "@/cmd/run";
+import { registerRunFileCommand } from "@/cmd/run-file";
+import { config } from "@/lib/config";
+import { fetchSecretsWithCache } from "@/lib/secretCache";
+
+describe("command fast exits", () => {
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+    let tracker: CommandTracker;
+    let trackerSuccess: ReturnType<typeof vi.fn<(properties?: Record<string, unknown>) => void>>;
+    let trackerError: ReturnType<typeof vi.fn<(error: unknown) => void>>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        trackerSuccess = vi.fn<(properties?: Record<string, unknown>) => void>();
+        trackerError = vi.fn<(error: unknown) => void>();
+        tracker = {
+            success: trackerSuccess,
+            error: trackerError,
+        };
+
+        vi.mocked(analytics.trackCommand).mockReturnValue(tracker);
+        vi.mocked(config.findProjectConfig).mockResolvedValue(FAKE_PROJECT_CONFIG);
+        vi.mocked(fetchSecretsWithCache).mockResolvedValue({
+            secrets: FAKE_SECRETS,
+            fromCache: false,
+        });
+
+        vi.stubGlobal("Bun", {
+            spawn: vi.fn(() => ({
+                exited: Promise.resolve(0),
+            })),
+            file: vi.fn(() => ({
+                exists: () => Promise.resolve(true),
+                text: () => Promise.resolve("key=${API_KEY}"),
+            })),
+        });
+
+        exitSpy = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => undefined) as never);
+        stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(((_chunk, encoding, callback) => {
+            const done = typeof encoding === "function" ? encoding : callback;
+            done?.();
+            return true;
+        }) as typeof process.stdout.write);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        exitSpy.mockRestore();
+        stdoutWriteSpy.mockRestore();
+        vi.restoreAllMocks();
+    });
+
+    it("exits immediately after a successful run command", async () => {
+        const program = new Command();
+        registerRunCommand(program);
+
+        await expect(program.parseAsync(["node", "ek", "run", "env"])).resolves.toBe(program);
+        expect(exitSpy).toHaveBeenCalledWith(0);
+        expect(trackerSuccess).toHaveBeenCalledOnce();
+        expect(trackerError).not.toHaveBeenCalled();
+    });
+
+    it("exits immediately after a successful run-file command", async () => {
+        const program = new Command();
+        registerRunFileCommand(program);
+
+        await expect(program.parseAsync(["node", "ek", "run-file", "--file", "/tmp/template.txt"])).resolves.toBe(
+            program,
+        );
+        expect(exitSpy).toHaveBeenCalledWith(0);
+        expect(stdoutWriteSpy.mock.calls[0]?.[0]).toBe("key=sk-test-abc123");
+        expect(trackerSuccess).toHaveBeenCalledOnce();
+        expect(trackerError).not.toHaveBeenCalled();
+    });
+});

--- a/tests/integration/run-file-command.test.ts
+++ b/tests/integration/run-file-command.test.ts
@@ -47,7 +47,11 @@ describe("runFileCommand (integration)", () => {
             file: mockFile,
         });
 
-        stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+        stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(((_chunk, encoding, callback) => {
+            const done = typeof encoding === "function" ? encoding : callback;
+            done?.();
+            return true;
+        }) as typeof process.stdout.write);
 
         vi.mocked(fetchSecretsWithCache).mockResolvedValue({
             secrets: FAKE_SECRETS,
@@ -71,7 +75,7 @@ describe("runFileCommand (integration)", () => {
 
         await runFileCommand(FAKE_PROJECT_CONFIG, "/tmp/template.txt");
 
-        expect(stdoutWriteSpy).toHaveBeenCalledWith("conn=postgres://localhost:5432/db");
+        expect(stdoutWriteSpy.mock.calls[0]?.[0]).toBe("conn=postgres://localhost:5432/db");
     });
 
     it("replaces multiple variables in one file", async () => {
@@ -128,7 +132,7 @@ describe("runFileCommand (integration)", () => {
 
         await runFileCommand(FAKE_PROJECT_CONFIG, "/tmp/empty.txt");
 
-        expect(stdoutWriteSpy).toHaveBeenCalledWith("");
+        expect(stdoutWriteSpy.mock.calls[0]?.[0]).toBe("");
     });
 
     it("handles secrets with empty string values (replaces with empty)", async () => {
@@ -144,7 +148,7 @@ describe("runFileCommand (integration)", () => {
 
         await runFileCommand(FAKE_PROJECT_CONFIG, "/tmp/template.txt");
 
-        expect(stdoutWriteSpy).toHaveBeenCalledWith("beforeafter");
+        expect(stdoutWriteSpy.mock.calls[0]?.[0]).toBe("beforeafter");
     });
 });
 

--- a/tests/unit/inject.test.ts
+++ b/tests/unit/inject.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Secret } from "@/api/client";
+
+vi.mock("@/lib/logger", () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        success: vi.fn(),
+        stderr: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            success: vi.fn(),
+        },
+    },
+}));
+
+import { logger } from "@/lib/logger";
+import { buildEnvWithSecrets, isDangerousEnvVar } from "@/lib/inject";
+
+function makeSecret(name: string, value: string): Secret {
+    return { id: `s-${name}`, name, value, isPersonal: false, environmentId: "env-test-123" };
+}
+
+describe("isDangerousEnvVar", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("blocks PATH", () => {
+        expect(isDangerousEnvVar("PATH")).toBe(true);
+    });
+
+    it("blocks JAVA_TOOL_OPTIONS", () => {
+        expect(isDangerousEnvVar("JAVA_TOOL_OPTIONS")).toBe(true);
+    });
+
+    it("blocks NODE_OPTIONS", () => {
+        expect(isDangerousEnvVar("NODE_OPTIONS")).toBe(true);
+    });
+
+    it("blocks HTTP_PROXY (uppercase)", () => {
+        expect(isDangerousEnvVar("HTTP_PROXY")).toBe(true);
+    });
+
+    it("blocks http_proxy (lowercase, case-insensitive check)", () => {
+        expect(isDangerousEnvVar("http_proxy")).toBe(true);
+    });
+
+    it("blocks LD_PRELOAD", () => {
+        expect(isDangerousEnvVar("LD_PRELOAD")).toBe(true);
+    });
+
+    it("blocks DOTNET_STARTUP_HOOKS", () => {
+        expect(isDangerousEnvVar("DOTNET_STARTUP_HOOKS")).toBe(true);
+    });
+
+    it("blocks GIT_SSH_COMMAND", () => {
+        expect(isDangerousEnvVar("GIT_SSH_COMMAND")).toBe(true);
+    });
+
+    it("blocks PROMPT_COMMAND", () => {
+        expect(isDangerousEnvVar("PROMPT_COMMAND")).toBe(true);
+    });
+
+    it("allows normal secret names", () => {
+        expect(isDangerousEnvVar("MY_APP_SECRET")).toBe(false);
+        expect(isDangerousEnvVar("DATABASE_URL")).toBe(false);
+        expect(isDangerousEnvVar("API_KEY")).toBe(false);
+    });
+
+    it("returns false for empty/invalid input", () => {
+        expect(isDangerousEnvVar("")).toBe(false);
+    });
+});
+
+describe("buildEnvWithSecrets", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    // --- Basic injection ---
+
+    it("injects secrets into env", () => {
+        const secrets = [makeSecret("DB_URL", "postgres://localhost"), makeSecret("API_KEY", "sk-123")];
+        const { env, injectedCount, skippedSecrets } = buildEnvWithSecrets(secrets);
+
+        expect(env.DB_URL).toBe("postgres://localhost");
+        expect(env.API_KEY).toBe("sk-123");
+        expect(injectedCount).toBe(2);
+        expect(skippedSecrets).toEqual([]);
+    });
+
+    // --- Stats / counts ---
+
+    it("returns correct injectedCount and skippedSecrets", () => {
+        const secrets = [makeSecret("DB_URL", "value"), makeSecret("PATH", "/bad"), makeSecret("API_KEY", "key")];
+        const { injectedCount, skippedSecrets } = buildEnvWithSecrets(secrets);
+
+        expect(injectedCount).toBe(2);
+        expect(skippedSecrets).toEqual(["PATH"]);
+    });
+
+    // --- Dangerous env var blocking ---
+
+    it("skips dangerous env vars by default", () => {
+        const secrets = [makeSecret("JAVA_TOOL_OPTIONS", "-agentlib:jdwp")];
+        const { env, injectedCount, skippedSecrets } = buildEnvWithSecrets(secrets);
+
+        expect(env.JAVA_TOOL_OPTIONS).toBeUndefined();
+        expect(injectedCount).toBe(0);
+        expect(skippedSecrets).toEqual(["JAVA_TOOL_OPTIONS"]);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("JAVA_TOOL_OPTIONS"));
+    });
+
+    it("allows dangerous env vars with allowDangerousVars option", () => {
+        const secrets = [makeSecret("NODE_OPTIONS", "--require=evil.js")];
+        const { env, injectedCount } = buildEnvWithSecrets(secrets, { allowDangerousVars: true });
+
+        expect(env.NODE_OPTIONS).toBe("--require=evil.js");
+        expect(injectedCount).toBe(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("Protected environment variable checks are disabled"),
+        );
+    });
+
+    // --- Carriage return warning ---
+
+    it("warns about \\r in secret values but still injects", () => {
+        const secrets = [makeSecret("TOKEN", "value\rwith\rcr")];
+        const { env, injectedCount } = buildEnvWithSecrets(secrets);
+
+        expect(env.TOKEN).toBe("value\rwith\rcr");
+        expect(injectedCount).toBe(1);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("carriage return"));
+    });
+
+    it("does not warn for normal values without \\r", () => {
+        const secrets = [makeSecret("NORMAL", "just-a-value")];
+        buildEnvWithSecrets(secrets);
+
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("does not warn for values with \\n only (no \\r)", () => {
+        const secrets = [makeSecret("PRIVATE_KEY", "-----BEGIN-----\nkey-data\n-----END-----")];
+        buildEnvWithSecrets(secrets);
+
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    // --- Null byte filtering ---
+
+    it("skips secrets with null bytes in name", () => {
+        const secrets = [makeSecret("BAD\0NAME", "value")];
+        const { injectedCount, skippedSecrets } = buildEnvWithSecrets(secrets);
+
+        expect(injectedCount).toBe(0);
+        expect(skippedSecrets).toEqual(["BAD\0NAME"]);
+    });
+
+    it("skips secrets with null bytes in value", () => {
+        const secrets = [makeSecret("KEY", "val\0ue")];
+        const { injectedCount, skippedSecrets } = buildEnvWithSecrets(secrets);
+
+        expect(injectedCount).toBe(0);
+        expect(skippedSecrets).toEqual(["KEY"]);
+    });
+
+    // --- Prefix mode ---
+
+    it("prefixes secret names with --prefix option", () => {
+        const secrets = [makeSecret("DB_URL", "postgres://localhost"), makeSecret("API_KEY", "sk-123")];
+        const { env } = buildEnvWithSecrets(secrets, { prefix: "EK_" });
+
+        expect(env.EK_DB_URL).toBe("postgres://localhost");
+        expect(env.EK_API_KEY).toBe("sk-123");
+        // Original names should not be set (unless they were in process.env)
+        expect(env.DB_URL).toBeUndefined();
+        expect(env.API_KEY).toBeUndefined();
+    });
+
+    it("does not prefix without --prefix option", () => {
+        const secrets = [makeSecret("DB_URL", "postgres://localhost")];
+        const { env } = buildEnvWithSecrets(secrets);
+
+        expect(env.DB_URL).toBe("postgres://localhost");
+    });
+
+    it("checks dangerous var against original name (not prefixed)", () => {
+        const secrets = [makeSecret("PATH", "/evil")];
+        const { skippedSecrets } = buildEnvWithSecrets(secrets, { prefix: "EK_" });
+
+        // PATH should still be blocked even with prefix
+        expect(skippedSecrets).toEqual(["PATH"]);
+    });
+});

--- a/tests/unit/run-file.test.ts
+++ b/tests/unit/run-file.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Secret } from "@/api/client";
+
+vi.mock("@/lib/logger", () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        success: vi.fn(),
+        stderr: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            success: vi.fn(),
+        },
+    },
+}));
+
+import { logger } from "@/lib/logger";
+import { replaceVariables } from "@/cmd/run-file";
+
+function makeSecret(name: string, value: string): Secret {
+    return { id: `s-${name}`, name, value, isPersonal: false, environmentId: "env-test-123" };
+}
+
+describe("replaceVariables — CRLF protection", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("strips \\r from substituted values (CRLF → LF)", () => {
+        const secrets = [makeSecret("TOKEN", "test\r\nvalue")];
+        const result = replaceVariables("key=${TOKEN}", secrets);
+        expect(result).toBe("key=test\nvalue");
+    });
+
+    it("strips standalone \\r from substituted values", () => {
+        const secrets = [makeSecret("TOKEN", "test\rJAVA_TOOL_OPTIONS=-agent\rLOGGING=http://evil")];
+        const result = replaceVariables("key=${TOKEN}", secrets);
+        expect(result).toBe("key=testJAVA_TOOL_OPTIONS=-agentLOGGING=http://evil");
+    });
+
+    it("preserves \\n in substituted values (private keys, certs)", () => {
+        const secrets = [makeSecret("KEY", "-----BEGIN-----\ndata\n-----END-----")];
+        const result = replaceVariables("cert=${KEY}", secrets);
+        expect(result).toBe("cert=-----BEGIN-----\ndata\n-----END-----");
+    });
+
+    it("does not modify values without \\r", () => {
+        const secrets = [makeSecret("NORMAL", "just-a-value")];
+        const result = replaceVariables("x=${NORMAL}", secrets);
+        expect(result).toBe("x=just-a-value");
+    });
+
+    it("strips \\r from multiple different secrets in same template", () => {
+        const secrets = [makeSecret("A", "val\r1"), makeSecret("B", "val\r2")];
+        const result = replaceVariables("${A} and ${B}", secrets);
+        expect(result).toBe("val1 and val2");
+    });
+});
+
+describe("replaceVariables — dangerous var name warnings", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("warns when substituting a dangerous variable name", () => {
+        const secrets = [makeSecret("PATH", "/some/path")];
+        const result = replaceVariables("p=${PATH}", secrets);
+
+        // Value is still substituted (templates are explicit)
+        expect(result).toBe("p=/some/path");
+        expect(logger.stderr.warn).toHaveBeenCalledWith(expect.stringContaining("protected environment variable"));
+    });
+
+    it("warns for NODE_OPTIONS", () => {
+        const secrets = [makeSecret("NODE_OPTIONS", "--max-old-space-size=4096")];
+        replaceVariables("opts=${NODE_OPTIONS}", secrets);
+
+        expect(logger.stderr.warn).toHaveBeenCalledWith(expect.stringContaining("NODE_OPTIONS"));
+    });
+
+    it("does not warn for normal variable names", () => {
+        const secrets = [makeSecret("DATABASE_URL", "postgres://localhost")];
+        replaceVariables("db=${DATABASE_URL}", secrets);
+
+        expect(logger.stderr.warn).not.toHaveBeenCalledWith(expect.stringContaining("protected"));
+    });
+
+    it("suppresses dangerous var warning with allowDangerousVars option", () => {
+        const secrets = [makeSecret("PATH", "/some/path")];
+        const result = replaceVariables("p=${PATH}", secrets, { allowDangerousVars: true });
+
+        expect(result).toBe("p=/some/path");
+        expect(logger.stderr.warn).not.toHaveBeenCalledWith(expect.stringContaining("protected"));
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - --allow-dangerous-vars flag to optionally permit protected env var injection (emits a warning).
  - --prefix option to namespace injected secrets.
  - SDK command gains --output mode (env or stdout) with direct token printing.
  - Success reporting shows number of injected secrets and any skipped secrets; commands now explicitly exit with the command exit code.

* **Improvements**
  - Strip carriage returns from substituted secret values.
  - Expanded protected-variable blocklist and clearer warnings.
  - More reliable, awaited stdout writes.

* **Tests**
  - Added unit and integration tests covering injection, substitution, warnings, and fast-exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->